### PR TITLE
Feat/notification scheduler batch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	compileOnly 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -35,7 +37,62 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// JJWT
+	// JJWTplugins {
+	//	id 'java'
+	//	id 'org.springframework.boot' version '3.5.3'
+	//	id 'io.spring.dependency-management' version '1.1.7'
+	//}
+	//
+	//group = 'com.shinhan'
+	//version = '0.0.1-SNAPSHOT'
+	//
+	//java {
+	//	toolchain {
+	//		languageVersion = JavaLanguageVersion.of(17)
+	//	}
+	//}
+	//
+	//configurations {
+	//	compileOnly {
+	//		extendsFrom annotationProcessor
+	//	}
+	//}
+	//
+	//repositories {
+	//	mavenCentral()
+	//}
+	//
+	//dependencies {
+	//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	//	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//	compileOnly 'org.projectlombok:lombok'
+	//	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	//	runtimeOnly 'com.h2database:h2'
+	//	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	//	annotationProcessor 'org.projectlombok:lombok'
+	//	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	//	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	//
+	//	// JJWT
+	//
+	//	// jjwt
+	//	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	//	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	//	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	//
+	//	// bCrput
+	//	implementation 'org.mindrot:jbcrypt:0.4'
+	//
+	//	// coolSMS(메시지 전송)
+	//	implementation 'net.nurigo:sdk:4.3.2'
+	//
+	//	implementation 'com.github.ben-manes.caffeine:caffeine'
+	//}
+	//
+	//tasks.named('test') {
+	//	useJUnitPlatform()
+	//}
 
 	// jjwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/src/main/java/com/shinhan/pda_midterm_project/PdaMidtermProjectApplication.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/PdaMidtermProjectApplication.java
@@ -2,8 +2,10 @@ package com.shinhan.pda_midterm_project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PdaMidtermProjectApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/shinhan/pda_midterm_project/common/batch/InitialDataLoader.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/batch/InitialDataLoader.java
@@ -1,0 +1,37 @@
+package com.shinhan.pda_midterm_project.common.batch;
+
+import com.shinhan.pda_midterm_project.domain.member.model.Member;
+import com.shinhan.pda_midterm_project.domain.member.repository.MemberRepository;
+import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
+import com.shinhan.pda_midterm_project.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InitialDataLoader implements CommandLineRunner {
+
+    private final MemberRepository memberRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // ⚡ 100명 Member 생성 + 각 Member 알림 생성
+//        for (int i = 1; i <= 100; i++) {
+//            Member member = memberRepository.save(Member.builder()
+//                    .memberId("user" + i)
+//                    .memberPassword("pw" + i)
+//                    .memberPhone("010-0000-" + String.format("%04d", i))
+//                    .build());
+//
+//            notificationRepository.save(Notification.builder()
+//                    .member(member)
+//                    .notificationTitle("알림 타이틀 " + i)
+//                    .notificationContent("이것은 " + i + "번째 유저의 테스트 알림입니다.")
+//                    .notificationIsRead(false)
+//                    .notificationUrl("/sample/url/" + i)
+//                    .build());
+//        }
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
@@ -1,0 +1,42 @@
+package com.shinhan.pda_midterm_project.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+
+    @Bean
+    public Job sampleJob(JobRepository jobRepository, Step sampleStep) {
+        return new JobBuilder("sampleJob", jobRepository)
+                .start(sampleStep)
+                .build();
+    }
+
+    @Bean
+    public Step sampleStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("sampleStep", jobRepository)
+                .tasklet(sampleTasklet(), transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Tasklet sampleTasklet() {
+        return (contribution, chunkContext) -> {
+            log.info(">>> [Spring Batch] ");
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
@@ -1,17 +1,24 @@
 package com.shinhan.pda_midterm_project.common.config;
 
+import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
+import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
-import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @Configuration
@@ -26,17 +33,52 @@ public class BatchConfig {
     }
 
     @Bean
-    public Step sampleStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+    public Step sampleStep(JobRepository jobRepository,
+                           PlatformTransactionManager transactionManager,
+                           ListItemReader<Long> memberIdReader,
+                           ItemProcessor<Long, List<Notification>> notificationProcessor,
+                           ItemWriter<List<Notification>> notificationWriter) {
+
         return new StepBuilder("sampleStep", jobRepository)
-                .tasklet(sampleTasklet(), transactionManager)
+                .<Long, List<Notification>>chunk(5, transactionManager) // 일단 테스트 수준에서 5명씩 처리
+                .reader(memberIdReader)
+                .processor(notificationProcessor)
+                .writer(notificationWriter)
                 .build();
     }
 
     @Bean
-    public Tasklet sampleTasklet() {
-        return (contribution, chunkContext) -> {
-            log.info(">>> [Spring Batch] ");
-            return RepeatStatus.FINISHED;
+    @StepScope
+    public ListItemReader<Long> memberIdReader(NotificationService notificationService) {
+        List<Long> allIds = new ArrayList<>(notificationService.getConnectedUserIds());
+        log.info(">>> [Reader] 접속 중인 유저 IDs: {}", allIds);
+        return new ListItemReader<>(allIds);
+    }
+
+    @Bean
+    public ItemProcessor<Long, List<Notification>> notificationProcessor(NotificationService notificationService) {
+        return memberId -> {
+            var notifications = notificationService.getTodaysNotifications(memberId);
+            log.info(">>> [Processor] memberId: {}, 알림 개수: {}", memberId, notifications.size());
+            return notifications;
+        };
+    }
+
+    @Bean
+    public ItemWriter<List<Notification>> notificationWriter(NotificationService notificationService) {
+        return notificationLists -> {
+            log.info(">>> [Writer] 이번 Chunk에 포함된 유저 수: {}", notificationLists.size());
+            for (List<Notification> notifications : notificationLists) {
+                if (!notifications.isEmpty()) {
+                    Long memberId = notifications.get(0).getMember().getId();
+                    for (Notification notification : notifications) {
+                        notificationService.sendNotification(memberId, notification.getNotificationContent());
+                        log.info(">>> [Writer] 알림 전송 완료 - memberId: {}", memberId);
+                    }
+                } else {
+                    log.info(">>> [Writer] 알림 없음 - 건너뜀");
+                }
+            }
         };
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/common/util/SseEmitterRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/util/SseEmitterRepository.java
@@ -35,4 +35,8 @@ public class SseEmitterRepository {
     public void delete(Long memberId) {
         emitterMap.remove(memberId);
     }
+
+    public Map<Long, SseEmitter> getEmitterMap() {
+        return emitterMap;
+    }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/config/NotificationBatchConfig.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/config/NotificationBatchConfig.java
@@ -1,4 +1,4 @@
-package com.shinhan.pda_midterm_project.common.config;
+package com.shinhan.pda_midterm_project.domain.notification.config;
 
 import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
 import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
@@ -23,23 +23,23 @@ import java.util.List;
 @Slf4j
 @Configuration
 @EnableBatchProcessing
-public class BatchConfig {
+public class NotificationBatchConfig {
 
     @Bean
-    public Job sampleJob(JobRepository jobRepository, Step sampleStep) {
-        return new JobBuilder("sampleJob", jobRepository)
-                .start(sampleStep)
+    public Job notificationSendJob(JobRepository jobRepository, Step notificationSendStep) {
+        return new JobBuilder("notificationSendJob", jobRepository)
+                .start(notificationSendStep)
                 .build();
-    }
+}
 
     @Bean
-    public Step sampleStep(JobRepository jobRepository,
+    public Step notificationSendStep(JobRepository jobRepository,
                            PlatformTransactionManager transactionManager,
                            ListItemReader<Long> memberIdReader,
                            ItemProcessor<Long, List<Notification>> notificationProcessor,
                            ItemWriter<List<Notification>> notificationWriter) {
 
-        return new StepBuilder("sampleStep", jobRepository)
+        return new StepBuilder("notificationSendStep", jobRepository)
                 .<Long, List<Notification>>chunk(5, transactionManager) // 일단 테스트 수준에서 5명씩 처리
                 .reader(memberIdReader)
                 .processor(notificationProcessor)

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/repository/NotificationRepository.java
@@ -1,9 +1,14 @@
 package com.shinhan.pda_midterm_project.domain.notification.repository;
 
 import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -19,6 +19,7 @@ public class NotificationScheduler {
 
 //    @Scheduled(cron = "*/5 * * * * ?")
 //    @Scheduled(cron = "0 0 8 * * ?")
+//    @Scheduled(cron = "0 */1 * * * ?")
     @Scheduled(cron = "0 0 8 * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -1,0 +1,23 @@
+package com.shinhan.pda_midterm_project.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+    private final NotificationService notificationService;
+
+//    @Scheduled(cron = "*/5 * * * * ?")
+    @Scheduled(cron = "0 0 8 * * ?")
+    public void sendMorningNotifications() {
+        log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");
+
+        notificationService.sendBatchNotifications();
+
+        log.info("알림 발송 완료");
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -2,6 +2,10 @@ package com.shinhan.pda_midterm_project.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,13 +14,25 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NotificationScheduler {
     private final NotificationService notificationService;
+    private final JobLauncher jobLauncher;
+    private final Job sampleJob;
 
 //    @Scheduled(cron = "*/5 * * * * ?")
+//    @Scheduled(cron = "0 0 8 * * ?")
     @Scheduled(cron = "0 0 8 * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");
 
-        notificationService.sendBatchNotifications();
+        // Spring Batch Job 실행
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters();
+            jobLauncher.run(sampleJob, params);
+            log.info("Spring Batch Job 실행 완료");
+        } catch (Exception e) {
+            log.error("Spring Batch Job 실행 중 오류", e);
+        }
 
         log.info("알림 발송 완료");
     }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -15,12 +15,12 @@ import org.springframework.stereotype.Component;
 public class NotificationScheduler {
     private final NotificationService notificationService;
     private final JobLauncher jobLauncher;
-    private final Job sampleJob;
+    private final Job notificationSendJob;
 
 //    @Scheduled(cron = "*/5 * * * * ?")
 //    @Scheduled(cron = "0 0 8 * * ?")
 //    @Scheduled(cron = "0 */1 * * * ?")
-    @Scheduled(cron = "0 0 8 * * ?")
+    @Scheduled(cron = "0 */1 * * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");
 
@@ -29,7 +29,7 @@ public class NotificationScheduler {
             JobParameters params = new JobParametersBuilder()
                     .addLong("time", System.currentTimeMillis())
                     .toJobParameters();
-            jobLauncher.run(sampleJob, params);
+            jobLauncher.run(notificationSendJob, params);
             log.info("Spring Batch Job 실행 완료");
         } catch (Exception e) {
             log.error("Spring Batch Job 실행 중 오류", e);

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -57,8 +57,4 @@ public class NotificationService {
         }
     }
 
-    public void sendBatchNotifications() {
-        log.info("배치시작");
-
-    }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.shinhan.pda_midterm_project.domain.notification.service;
 
 import com.shinhan.pda_midterm_project.common.util.SseEmitterRepository;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -54,5 +55,10 @@ public class NotificationService {
         } else {
             log.warn(">>> [알림 전송 실패] emitter 없음");
         }
+    }
+
+    public void sendBatchNotifications() {
+        log.info("배치시작");
+
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -1,7 +1,7 @@
 package com.shinhan.pda_midterm_project.domain.notification.service;
 
 import com.shinhan.pda_midterm_project.common.util.SseEmitterRepository;
-import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -9,10 +9,12 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class NotificationService {
 
     private final SseEmitterRepository emitterRepository;
+    public NotificationService(SseEmitterRepository emitterRepository) {
+        this.emitterRepository = emitterRepository;
+    }
 
     /**
      * 클라이언트와 SSE 연결을 생성하고 emitter를 저장
@@ -55,6 +57,10 @@ public class NotificationService {
         } else {
             log.warn(">>> [알림 전송 실패] emitter 없음");
         }
+    }
+
+    public Set<Long> getConnectedUserIds() {
+        return emitterRepository.getEmitterMap().keySet();
     }
 
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/test/BatchTestRunner.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/test/BatchTestRunner.java
@@ -1,0 +1,27 @@
+package com.shinhan.pda_midterm_project.test;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BatchTestRunner implements CommandLineRunner {
+    private final JobLauncher jobLauncher;
+    private final Job sampleJob;
+
+    public BatchTestRunner(JobLauncher jobLauncher, Job sampleJob) {
+        this.jobLauncher = jobLauncher;
+        this.sampleJob = sampleJob;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        JobParameters params = new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+        jobLauncher.run(sampleJob, params);
+    }
+} 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,12 @@ spring:
     include:
       - jwt
       - coolSMS
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/test/java/com/shinhan/pda_midterm_project/domain/auth/service/NotificationServiceTest.java
+++ b/src/test/java/com/shinhan/pda_midterm_project/domain/auth/service/NotificationServiceTest.java
@@ -1,33 +1,42 @@
 package com.shinhan.pda_midterm_project.domain.auth.service;
 
 import com.shinhan.pda_midterm_project.common.util.SseEmitterRepository;
+import com.shinhan.pda_midterm_project.domain.notification.repository.NotificationRepository;
 import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 class NotificationServiceTest {
 
     private NotificationService notificationService;
     private SseEmitterRepository emitterRepository;
+    private NotificationRepository notificationRepository;
 
     @BeforeEach
     void setUp() {
         emitterRepository = new SseEmitterRepository();
-        notificationService = new NotificationService(emitterRepository);
+        notificationRepository = mock(NotificationRepository.class);
+        notificationService = new NotificationService(emitterRepository, notificationRepository);
     }
 
     @Test
     void 여러_유저_접속_모사_및_ID_출력_테스트() {
         // Given — 유저 3명 접속 시뮬
-        notificationService.connect(1L);
-        notificationService.connect(2L);
-        notificationService.connect(3L);
+
+        notificationService.connect(4L);
+        notificationService.connect(5L);
+        notificationService.connect(6L);
+        notificationService.connect(7L);
+        notificationService.connect(8L);
+        notificationService.connect(9L);
+        notificationService.connect(10L);
+        notificationService.connect(11L);
+        notificationService.connect(12L);
+        notificationService.connect(13L);
 
         System.out.println(">>> emitterMap 상태: " + emitterRepository.getEmitterMap());
 
@@ -38,7 +47,7 @@ class NotificationServiceTest {
         connectedIds.forEach(id -> System.out.println("접속 중인 유저 ID: " + id));
 
         // 검증
-        assertThat(connectedIds).containsExactlyInAnyOrder(1L, 2L, 3L);
+        assertThat(connectedIds).containsExactlyInAnyOrder(4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L);
     }
 
 }

--- a/src/test/java/com/shinhan/pda_midterm_project/domain/auth/service/NotificationServiceTest.java
+++ b/src/test/java/com/shinhan/pda_midterm_project/domain/auth/service/NotificationServiceTest.java
@@ -1,17 +1,44 @@
 package com.shinhan.pda_midterm_project.domain.auth.service;
 
+import com.shinhan.pda_midterm_project.common.util.SseEmitterRepository;
+import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-@ExtendWith(MockitoExtension.class)
-@Slf4j
-public class NotificationServiceTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class NotificationServiceTest {
+
+    private NotificationService notificationService;
+    private SseEmitterRepository emitterRepository;
+
+    @BeforeEach
+    void setUp() {
+        emitterRepository = new SseEmitterRepository();
+        notificationService = new NotificationService(emitterRepository);
+    }
 
     @Test
-    void basicLogTest() {
-        log.info("테스트 잘됨");
+    void 여러_유저_접속_모사_및_ID_출력_테스트() {
+        // Given — 유저 3명 접속 시뮬
+        notificationService.connect(1L);
+        notificationService.connect(2L);
+        notificationService.connect(3L);
+
+        System.out.println(">>> emitterMap 상태: " + emitterRepository.getEmitterMap());
+
+        // When — 현재 접속 중인 유저 ID 가져오기
+        Set<Long> connectedIds = notificationService.getConnectedUserIds();
+
+        // Then — ID 출력
+        connectedIds.forEach(id -> System.out.println("접속 중인 유저 ID: " + id));
+
+        // 검증
+        assertThat(connectedIds).containsExactlyInAnyOrder(1L, 2L, 3L);
     }
 
 }

--- a/src/test/java/com/shinhan/pda_midterm_project/domain/auth/service/NotificationServiceTest.java
+++ b/src/test/java/com/shinhan/pda_midterm_project/domain/auth/service/NotificationServiceTest.java
@@ -1,0 +1,17 @@
+package com.shinhan.pda_midterm_project.domain.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import lombok.extern.slf4j.Slf4j;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class NotificationServiceTest {
+
+    @Test
+    void basicLogTest() {
+        log.info("테스트 잘됨");
+    }
+
+}


### PR DESCRIPTION

## 🔀 PR 개요
- 접속 중인 유저를 대상으로 5명씩 배치 단위로 알림을 전송하는 기능을 Spring Batch + 스케줄러를 통해 구현했습니다.

---

## ✅ 작업 내용
- Spring Batch 기본 설정 및 Job/Step/Tasklet → Chunk 기반 구조 변경
- 접속 유저 ID를 emitterMap에서 조회하여 ListItemReader로 읽어오기
- 5명씩 chunk 단위로 알림을 처리하도록 Step 구성
- 오늘 생성된 알림만 필터링하여 전송
- 알림 전송 성공/실패 로깅 추가
- 테스트용 NotificationServiceTest 작성 (접속 시뮬 및 ID 검증)

---

## 📌 관련 이슈
- Close #19 

---

## ⚠️ 기타 사항
- 실제로 알림 발송 테스트는 브라우저에서 SSE 연결 후 진행 필요
- 알림 전송 시 emitter가 없거나 실패할 경우 로그로만 확인됩니다
