### PR TITLE
Refactor: 주식명 동기화 로직 개선

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/domain/earning_call/service/EarningCallServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/earning_call/service/EarningCallServiceImpl.java
@@ -88,13 +88,73 @@ public class EarningCallServiceImpl implements EarningCallService {
   }
 
   /**
-   * Stock이 있으면 조회하고, 없으면 생성
+   * Stock이 있으면 stockName을 업데이트하고, 없으면 생성
    */
   private Stock getOrCreateStock(String symbol, String stockName) {
     Optional<Stock> stockOptional = stockRepository.findById(symbol);
 
     if (stockOptional.isPresent()) {
-      return stockOptional.get();
+      Stock existingStock = stockOptional.get();
+      // 기존 Stock의 stockName을 CSV의 영문명으로 업데이트
+      if (!stockName.equals(existingStock.getStockName())) {
+        Stock updatedStock = Stock.builder()
+            .stockId(existingStock.getStockId())
+            .stockName(stockName) // CSV의 영문명으로 업데이트
+            .rsym(existingStock.getRsym())
+            .zdiv(existingStock.getZdiv())
+            .curr(existingStock.getCurr())
+            .vnit(existingStock.getVnit())
+            .open(existingStock.getOpen())
+            .high(existingStock.getHigh())
+            .low(existingStock.getLow())
+            .last(existingStock.getLast())
+            .base(existingStock.getBase())
+            .pvol(existingStock.getPvol())
+            .pamt(existingStock.getPamt())
+            .tvol(existingStock.getTvol())
+            .tamt(existingStock.getTamt())
+            .uplp(existingStock.getUplp())
+            .dnlp(existingStock.getDnlp())
+            .h52p(existingStock.getH52p())
+            .h52d(existingStock.getH52d())
+            .l52p(existingStock.getL52p())
+            .l52d(existingStock.getL52d())
+            .perx(existingStock.getPerx())
+            .pbrx(existingStock.getPbrx())
+            .epsx(existingStock.getEpsx())
+            .bpsx(existingStock.getBpsx())
+            .shar(existingStock.getShar())
+            .mcap(existingStock.getMcap())
+            .tomv(existingStock.getTomv())
+            .tXprc(existingStock.getTXprc())
+            .tXdif(existingStock.getTXdif())
+            .tXrat(existingStock.getTXrat())
+            .tRate(existingStock.getTRate())
+            .tXsgn(existingStock.getTXsgn())
+            .pXprc(existingStock.getPXprc())
+            .pXdif(existingStock.getPXdif())
+            .pXrat(existingStock.getPXrat())
+            .pRate(existingStock.getPRate())
+            .pXsng(existingStock.getPXsng())
+            .eOrdyn(existingStock.getEOrdyn())
+            .eHogau(existingStock.getEHogau())
+            .eIcod(existingStock.getEIcod())
+            .eParp(existingStock.getEParp())
+            .etypNm(existingStock.getEtypNm())
+            .stockImageUri(existingStock.getStockImageUri())
+            .stockIsDelisted(existingStock.getStockIsDelisted())
+            .ovrsPdno(existingStock.getOvrsPdno())
+            .ovrsItemName(existingStock.getOvrsItemName()) // 한글명은 유지
+            .ovrsExcgCd(existingStock.getOvrsExcgCd())
+            .trCrcyCd(existingStock.getTrCrcyCd())
+            .prdtTypeCd(existingStock.getPrdtTypeCd())
+            .build();
+
+        Stock savedStock = stockRepository.save(updatedStock);
+        log.info("Updated stock: symbol={}, stockName={} (was: {})", symbol, stockName, existingStock.getStockName());
+        return savedStock;
+      }
+      return existingStock;
     } else {
       // Stock이 없으면 새로 생성
       Stock newStock = Stock.builder()

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MemberServiceImpl.java
@@ -168,13 +168,13 @@ public class MemberServiceImpl implements MemberService {
             // 새로운 Stock 엔티티 생성 (기본 정보만)
             Stock stock = Stock.builder()
                     .stockId(item.getOvrsPdno())
-                    .stockName(item.getOvrsItemName())
+                    .stockName(item.getOvrsPdno()) // stockName은 종목코드로 설정 (영문명은 CSV에서 설정됨)
                     // 기본 주식 정보
                     .rsym(item.getOvrsPdno()) // 종목 심볼을 종목코드로 설정
                     .curr(item.getTrCrcyCd()) // 통화
                     // 해외주식 관련 필드들
                     .ovrsPdno(item.getOvrsPdno())
-                    .ovrsItemName(item.getOvrsItemName())
+                    .ovrsItemName(item.getOvrsItemName()) // 한글명은 ovrsItemName에 저장
                     .ovrsExcgCd(item.getOvrsExcgCd())
                     .trCrcyCd(item.getTrCrcyCd())
                     .stockIsDelisted(false)
@@ -192,13 +192,13 @@ public class MemberServiceImpl implements MemberService {
             // 새로운 Stock 엔티티 생성 (소수점 주식 정보)
             Stock stock = Stock.builder()
                     .stockId(item.getPdno())
-                    .stockName(item.getPrdtName())
+                    .stockName(item.getPdno()) // stockName은 종목코드로 설정 (영문명은 CSV에서 설정됨)
                     // 기본 주식 정보
                     .rsym(item.getPdno()) // 종목 심볼을 종목코드로 설정
                     .curr(item.getBuyCrcyCd()) // 통화
                     // 해외주식 관련 필드들 (소수점 주식의 경우 일부 필드가 다를 수 있음)
                     .ovrsPdno(item.getPdno())
-                    .ovrsItemName(item.getPrdtName())
+                    .ovrsItemName(item.getPrdtName()) // 한글명은 ovrsItemName에 저장
                     .ovrsExcgCd(item.getOvrsExcgCd() != null ? item.getOvrsExcgCd() : "NASD") // 기본값 설정
                     .trCrcyCd(item.getBuyCrcyCd())
                     .stockIsDelisted(false)

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/earningCall/dto/EarningCallResponseDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/earningCall/dto/EarningCallResponseDto.java
@@ -13,6 +13,7 @@ public class EarningCallResponseDto {
   private Long id;
   private String stockId;
   private String stockName;
+  private String ovrsItemName; // 해외종목명 (한글명) 추가
   private String earningCallDate;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
@@ -23,6 +24,7 @@ public class EarningCallResponseDto {
         .id(earningCall.getId())
         .stockId(stock != null ? stock.getStockId() : null)
         .stockName(stock != null ? stock.getStockName() : null)
+        .ovrsItemName(stock != null ? stock.getOvrsItemName() : null) // 해외종목명 추가
         .earningCallDate(earningCall.getEarningCallDate())
         .createdAt(earningCall.getCreatedAt())
         .updatedAt(earningCall.getUpdatedAt())


### PR DESCRIPTION
• EarningCallServiceImpl에서 기존 Stock의 stockName을 CSV 영문명으로 업데이트하는 로직 추가 • MemberServiceImpl에서 stockName을 종목코드로, ovrsItemName을 한글명으로 설정하도록 변경 • EarningCallResponseDto에 ovrsItemName 필드 추가하여 해외종목 한글명 제공

---
name: PR template
about: Describe this PR template's purpose here.
title: ''
labels: ''
assignees: ''

---

## 🔀 PR 개요
- 어떤 작업을 했는지 한 문장으로 요약해주세요.

---

## ✅ 작업 내용
- 주요 변경사항 리스트
- 어떤 기능이 추가/변경/삭제되었는지 명확하게 작성

---

## 📌 관련 이슈
- Close #이슈번호 (자동으로 연결되도록)

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
