### PR TITLE
Feat/notification api

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/domain/auth/service/TokenCookieManager.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/auth/service/TokenCookieManager.java
@@ -28,4 +28,15 @@ public class TokenCookieManager {
                 .path("/")
                 .build();
     }
+
+    public static ResponseCookie deleteCookie() {
+        return ResponseCookie.from(TOKEN_NAME, "")
+                .path("/")
+                .maxAge(0)
+                .secure(true)
+                .httpOnly(true)
+                .sameSite("none")
+                .build();
+    }
+
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/repository/NotificationRepository.java
@@ -11,4 +11,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
+    List<Notification> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -1,8 +1,11 @@
 package com.shinhan.pda_midterm_project.domain.notification.service;
 
 import com.shinhan.pda_midterm_project.common.util.SseEmitterRepository;
+import com.shinhan.pda_midterm_project.domain.member.model.Member;
+import com.shinhan.pda_midterm_project.domain.member.repository.MemberRepository;
 import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
 import com.shinhan.pda_midterm_project.domain.notification.repository.NotificationRepository;
+import com.shinhan.pda_midterm_project.presentation.notification.dto.NotificationResponseDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
@@ -16,10 +19,12 @@ public class NotificationService {
 
     private final SseEmitterRepository emitterRepository;
     private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
 
-    public NotificationService(SseEmitterRepository emitterRepository, NotificationRepository notificationRepository) {
+    public NotificationService(SseEmitterRepository emitterRepository, NotificationRepository notificationRepository, MemberRepository memberRepository) {
         this.emitterRepository = emitterRepository;
         this.notificationRepository = notificationRepository;
+        this.memberRepository = memberRepository;
     }
 
     /**
@@ -79,4 +84,15 @@ public class NotificationService {
         return notificationRepository.findByMemberIdAndCreatedAtBetween(memberId, startOfDay, endOfDay);
     }
 
+    public List<NotificationResponseDto> getByMemberId(Long memberId) {
+        return notificationRepository.findByMemberId(memberId).stream()
+                .map(n -> NotificationResponseDto.builder()
+                        .id(n.getId())
+                        .title(n.getNotificationTitle())
+                        .message(n.getNotificationContent())
+                        .read(n.getNotificationIsRead())
+                        .time(n.getCreatedAt())
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
@@ -5,9 +5,14 @@ import com.shinhan.pda_midterm_project.common.response.Response;
 import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
 import com.shinhan.pda_midterm_project.domain.auth.service.AuthService;
+import com.shinhan.pda_midterm_project.domain.member.model.Member;
+import com.shinhan.pda_midterm_project.domain.member.service.MemberService;
 import com.shinhan.pda_midterm_project.presentation.auth.dto.request.AuthRequest;
 import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
@@ -24,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
 	private final AuthService authService;
+	private final MemberService memberService;
 
 	@PostMapping("/login")
 	public ResponseEntity<Response<Object>> login(
@@ -32,12 +38,20 @@ public class AuthController {
 		String password = loginRequest.password();
 		ResponseCookie responseCookie = authService.login(id, password);
 
+		Member member = memberService.findByMemberId(id);
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("memberId", member.getId());
+		result.put("userIsLogin", true);
+
 		return ResponseEntity
 				.ok()
 				.header(HttpHeaders.SET_COOKIE, responseCookie.toString())
 				.body(Response.success(
 						ResponseMessages.LOGIN_SUCCESS.getCode(),
-						ResponseMessages.LOGIN_SUCCESS.getMessage()));
+						ResponseMessages.LOGIN_SUCCESS.getMessage(),
+						result
+				));
 	}
 
 	@PostMapping("/signup")

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.shinhan.pda_midterm_project.common.response.Response;
 import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
 import com.shinhan.pda_midterm_project.domain.auth.service.AuthService;
+import com.shinhan.pda_midterm_project.domain.auth.service.TokenCookieManager;
 import com.shinhan.pda_midterm_project.domain.member.model.Member;
 import com.shinhan.pda_midterm_project.domain.member.service.MemberService;
 import com.shinhan.pda_midterm_project.presentation.auth.dto.request.AuthRequest;
@@ -80,6 +81,14 @@ public class AuthController {
 					.body(Response.failure("401", "인증이 필요합니다."));
 		}
 		return ResponseEntity.ok(Response.success("200", "인증된 사용자입니다."));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout() {
+		return ResponseEntity
+				.ok()
+				.header(HttpHeaders.SET_COOKIE, TokenCookieManager.deleteCookie().toString())
+				.build();
 	}
 
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
@@ -39,19 +39,13 @@ public class AuthController {
 		String password = loginRequest.password();
 		ResponseCookie responseCookie = authService.login(id, password);
 
-		Member member = memberService.findByMemberId(id);
-
-		Map<String, Object> result = new HashMap<>();
-		result.put("memberId", member.getId());
-		result.put("userIsLogin", true);
-
 		return ResponseEntity
 				.ok()
 				.header(HttpHeaders.SET_COOKIE, responseCookie.toString())
 				.body(Response.success(
 						ResponseMessages.LOGIN_SUCCESS.getCode(),
 						ResponseMessages.LOGIN_SUCCESS.getMessage(),
-						result
+						Map.of("userIsLogin", true)
 				));
 	}
 

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
@@ -3,14 +3,11 @@ package com.shinhan.pda_midterm_project.presentation.notification.controller;
 import com.shinhan.pda_midterm_project.common.annotation.Auth;
 import com.shinhan.pda_midterm_project.common.annotation.MemberOnly;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
-import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
 import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
 import com.shinhan.pda_midterm_project.common.response.Response;
 
 import com.shinhan.pda_midterm_project.presentation.notification.dto.NotificationResponseDto;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,11 +25,12 @@ public class NotificationController {
      * 클라이언트가 SSE 연결을 요청할 때 호출되는 엔드포인트
      * 로그인 구현 후 memberId 추출 방식만 바꾸면 될듯
      *
-     * @param memberId 클라이언트의 회원 ID
      * @return SseEmitter (서버 → 클라이언트 실시간 통로)
      */
     @GetMapping("/stream")
-    public SseEmitter connect(@RequestParam Long memberId) {
+    @MemberOnly
+    public SseEmitter connect(@Auth Accessor accessor) {
+        Long memberId = accessor.memberId();
         return notificationService.connect(memberId);
     }
 

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
@@ -1,7 +1,18 @@
 package com.shinhan.pda_midterm_project.presentation.notification.controller;
 
+import com.shinhan.pda_midterm_project.common.annotation.Auth;
+import com.shinhan.pda_midterm_project.common.annotation.MemberOnly;
+import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
+import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
 import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
+import com.shinhan.pda_midterm_project.common.response.Response;
+
+import com.shinhan.pda_midterm_project.presentation.notification.dto.NotificationResponseDto;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -23,6 +34,14 @@ public class NotificationController {
     @GetMapping("/stream")
     public SseEmitter connect(@RequestParam Long memberId) {
         return notificationService.connect(memberId);
+    }
+
+    @GetMapping
+    @MemberOnly
+    public ResponseEntity<Response<Object>> getMemberNotifications(@Auth Accessor accessor) {
+        Long memberId = accessor.memberId();
+        List<NotificationResponseDto> result = notificationService.getByMemberId(memberId);
+        return ResponseEntity.ok(Response.success("200", "알림 조회 성공", result));
     }
 
     /**

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,14 @@
+package com.shinhan.pda_midterm_project.presentation.notification.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record NotificationResponseDto(
+        Long id,
+        String title,
+        String message,
+        Boolean read,
+        LocalDateTime time
+) {}


### PR DESCRIPTION

## 🔀 PR 개요
- SSE 알림 요청 시 쿠키 기반 인증

---

## ✅ 작업 내용
- [x] 로그인한 유저 기준 `SseEmitter` 생성 및 SSE 연결 `/api/v1/notifications/stream`
- [x] 로그아웃 또는 세션 만료 시 `emitterMap` 정리 로직 보완
- [x] `/api/v1/notifications` GET API 구현
  - 로그인한 회원의 알림 리스트 조회

---

## 📌 관련 이슈
- Close #39 


