### PR TITLE
Feat/mypage

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/common/config/WebConfig.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/config/WebConfig.java
@@ -20,7 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000") // 클라이언트의 origin
                 .allowCredentials(true) // credentials(쿠키 등)을 허용
-                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                 .allowedHeaders("*")
                 .maxAge(3600); // preflight 요청 캐시 시간 설정
     }

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -94,7 +94,8 @@ public enum ResponseMessages {
      * mypage
      */
     GET_MY_PAGE_SUCCESS("MYPAGE-001", "마이페이지 조회를 성공했습니다."),
-    UPDATE_NICKNAME_SUCCESS("MEMBER-003", "닉네임 변경에 성공했습니다.");
+    UPDATE_NICKNAME_SUCCESS("MEMBER-003", "닉네임 변경에 성공했습니다."),
+    UPDATE_INVESTMENT_TYPE_SUCCESS("MYPAGE-004", "투자 성향이 성공적으로 변경되었습니다.");
 
 
     // 도메인 추가해주세요

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -93,7 +93,9 @@ public enum ResponseMessages {
     /**
      * mypage
      */
-    GET_MY_PAGE_SUCCESS("MYPAGE-001", "마이페이지 조회를 성공했습니다.");
+    GET_MY_PAGE_SUCCESS("MYPAGE-001", "마이페이지 조회를 성공했습니다."),
+    UPDATE_NICKNAME_SUCCESS("MEMBER-003", "닉네임 변경에 성공했습니다.");
+
 
     // 도메인 추가해주세요
     private final String code;

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -88,7 +88,12 @@ public enum ResponseMessages {
     /**
      * member stock
      */
-    MEMBER_NO_STOCKS("MEMBER-STOCK-001", "사용자의 보유종목이 없습니다.");
+    MEMBER_NO_STOCKS("MEMBER-STOCK-001", "사용자의 보유종목이 없습니다."),
+
+    /**
+     * mypage
+     */
+    GET_MY_PAGE_SUCCESS("MYPAGE-001", "마이페이지 조회를 성공했습니다.");
 
     // 도메인 추가해주세요
     private final String code;

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member/model/Member.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member/model/Member.java
@@ -90,4 +90,8 @@ public class Member extends BaseEntity {
                 .memberPhone(memberPhone)
                 .build();
     }
+
+    public void updateInvestmentType(InvestmentType investmentType) {
+        this.investmentType = investmentType;
+    }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MemberService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MemberService.java
@@ -15,4 +15,6 @@ public interface MemberService {
      * 회원가입 후 해외주식 잔고 조회 및 저장
      */
     void fetchAndSaveMemberStocks(Member member);
+
+    void updateNickname(Long aLong, String nickname);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MemberServiceImpl.java
@@ -250,4 +250,10 @@ public class MemberServiceImpl implements MemberService {
             }
         }
     }
+
+    @Transactional
+    public void updateNickname(Long memberId, String newNickname) {
+        Member member = findById(memberId);
+        member.updateProfile(newNickname, member.getMemberPhone());
+    }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MyPageService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MyPageService.java
@@ -1,16 +1,20 @@
 package com.shinhan.pda_midterm_project.domain.member.service;
 
+import com.shinhan.pda_midterm_project.domain.investment_type.model.InvestmentType;
+import com.shinhan.pda_midterm_project.domain.investment_type.repository.InvestmentTypeRepository;
 import com.shinhan.pda_midterm_project.domain.member.model.Member;
 import com.shinhan.pda_midterm_project.domain.member.repository.MemberRepository;
 import com.shinhan.pda_midterm_project.presentation.member.dto.response.MyPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MyPageService {
 
     private final MemberRepository memberRepository;
+    private final InvestmentTypeRepository investmentTypeRepository;
 
     public MyPageResponse getMyPageInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -22,5 +26,16 @@ public class MyPageService {
                         ? member.getInvestmentType().getInvestmentName()
                         : null
         );
+    }
+
+    @Transactional
+    public void updateInvestmentType(Long memberId, Long investmentTypeId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        InvestmentType investmentType = investmentTypeRepository.findById(investmentTypeId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 투자 성향입니다."));
+
+        member.updateInvestmentType(investmentType);
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MyPageService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member/service/MyPageService.java
@@ -1,0 +1,26 @@
+package com.shinhan.pda_midterm_project.domain.member.service;
+
+import com.shinhan.pda_midterm_project.domain.member.model.Member;
+import com.shinhan.pda_midterm_project.domain.member.repository.MemberRepository;
+import com.shinhan.pda_midterm_project.presentation.member.dto.response.MyPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final MemberRepository memberRepository;
+
+    public MyPageResponse getMyPageInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        return new MyPageResponse(
+                member.getMemberNickname(),
+                member.getInvestmentType() != null
+                        ? member.getInvestmentType().getInvestmentName()
+                        : null
+        );
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/auth/controller/AuthController.java
@@ -3,14 +3,13 @@ package com.shinhan.pda_midterm_project.presentation.auth.controller;
 import com.shinhan.pda_midterm_project.common.annotation.Auth;
 import com.shinhan.pda_midterm_project.common.response.Response;
 import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
+import com.shinhan.pda_midterm_project.common.util.SseEmitterRepository;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
 import com.shinhan.pda_midterm_project.domain.auth.service.AuthService;
 import com.shinhan.pda_midterm_project.domain.auth.service.TokenCookieManager;
-import com.shinhan.pda_midterm_project.domain.member.model.Member;
 import com.shinhan.pda_midterm_project.domain.member.service.MemberService;
 import com.shinhan.pda_midterm_project.presentation.auth.dto.request.AuthRequest;
 import jakarta.validation.Valid;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -31,6 +31,7 @@ public class AuthController {
 
 	private final AuthService authService;
 	private final MemberService memberService;
+	private final SseEmitterRepository emitterRepository;
 
 	@PostMapping("/login")
 	public ResponseEntity<Response<Object>> login(
@@ -78,7 +79,12 @@ public class AuthController {
 	}
   
 	@PostMapping("/logout")
-	public ResponseEntity<Void> logout() {
+	public ResponseEntity<Void> logout(@Auth Accessor accessor) {
+		Long memberId = accessor.memberId();
+		emitterRepository.delete(memberId);
+
+		log.info("✅ [connect] 현재 emitterMap: {}", emitterRepository.getEmitterMap());
+
 		return ResponseEntity
 				.ok()
 				.header(HttpHeaders.SET_COOKIE, TokenCookieManager.deleteCookie().toString())

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/member/controller/MyPageController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/member/controller/MyPageController.java
@@ -9,6 +9,7 @@ import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
 import com.shinhan.pda_midterm_project.domain.member.service.MemberService;
 import com.shinhan.pda_midterm_project.domain.member.service.MyPageService;
+import com.shinhan.pda_midterm_project.presentation.member.dto.request.UpdateInvestmentTypeRequest;
 import com.shinhan.pda_midterm_project.presentation.member.dto.request.UpdateNicknameRequest;
 import com.shinhan.pda_midterm_project.presentation.member.dto.response.MyPageResponse;
 import jakarta.validation.Valid;
@@ -46,4 +47,17 @@ public class MyPageController {
                 ResponseMessages.UPDATE_NICKNAME_SUCCESS.getMessage()
         );
     }
+
+    @PatchMapping("/investment-type")
+    public Response<Void> updateInvestmentType(
+            @Auth Accessor accessor,
+            @RequestBody @Valid UpdateInvestmentTypeRequest request
+    ) {
+        myPageService.updateInvestmentType(accessor.memberId(), request.investmentTypeId());
+        return Response.success(
+                ResponseMessages.UPDATE_INVESTMENT_TYPE_SUCCESS.getCode(),
+                ResponseMessages.UPDATE_INVESTMENT_TYPE_SUCCESS.getMessage()
+        );
+    }
+
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/member/controller/MyPageController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/member/controller/MyPageController.java
@@ -5,11 +5,17 @@ import static com.shinhan.pda_midterm_project.common.response.ResponseMessages.G
 
 import com.shinhan.pda_midterm_project.common.annotation.Auth;
 import com.shinhan.pda_midterm_project.common.response.Response;
+import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
+import com.shinhan.pda_midterm_project.domain.member.service.MemberService;
 import com.shinhan.pda_midterm_project.domain.member.service.MyPageService;
+import com.shinhan.pda_midterm_project.presentation.member.dto.request.UpdateNicknameRequest;
 import com.shinhan.pda_midterm_project.presentation.member.dto.response.MyPageResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
     private final MyPageService myPageService;
+    private final MemberService memberService;
 
     @GetMapping
     public Response<MyPageResponse> getMyPageInfo(@Auth Accessor accessor) {
@@ -27,6 +34,16 @@ public class MyPageController {
                 GET_MY_PAGE_SUCCESS.getCode(),
                 GET_MY_PAGE_SUCCESS.getMessage(),
                 response
+        );
+    }
+
+    @PatchMapping("/nickname")
+    public Response<Void> updateNickname(@Auth Accessor accessor,
+                                         @Valid @RequestBody UpdateNicknameRequest request) {
+        memberService.updateNickname(accessor.memberId(), request.getNickname());
+        return Response.success(
+                ResponseMessages.UPDATE_NICKNAME_SUCCESS.getCode(),
+                ResponseMessages.UPDATE_NICKNAME_SUCCESS.getMessage()
         );
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/member/controller/MyPageController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/member/controller/MyPageController.java
@@ -1,0 +1,32 @@
+package com.shinhan.pda_midterm_project.presentation.member.controller;
+
+
+import static com.shinhan.pda_midterm_project.common.response.ResponseMessages.GET_MY_PAGE_SUCCESS;
+
+import com.shinhan.pda_midterm_project.common.annotation.Auth;
+import com.shinhan.pda_midterm_project.common.response.Response;
+import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
+import com.shinhan.pda_midterm_project.domain.member.service.MyPageService;
+import com.shinhan.pda_midterm_project.presentation.member.dto.response.MyPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public Response<MyPageResponse> getMyPageInfo(@Auth Accessor accessor) {
+        MyPageResponse response = myPageService.getMyPageInfo(accessor.memberId());
+        return Response.success(
+                GET_MY_PAGE_SUCCESS.getCode(),
+                GET_MY_PAGE_SUCCESS.getMessage(),
+                response
+        );
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/member/dto/request/UpdateInvestmentTypeRequest.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/member/dto/request/UpdateInvestmentTypeRequest.java
@@ -1,0 +1,7 @@
+package com.shinhan.pda_midterm_project.presentation.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateInvestmentTypeRequest(
+        @NotNull Long investmentTypeId
+) {}

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/member/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/member/dto/request/UpdateNicknameRequest.java
@@ -1,0 +1,10 @@
+package com.shinhan.pda_midterm_project.presentation.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameRequest {
+    @NotBlank(message = "닉네임은 공백일 수 없습니다.")
+    private String nickname;
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/member/dto/response/MyPageResponse.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/member/dto/response/MyPageResponse.java
@@ -1,0 +1,11 @@
+package com.shinhan.pda_midterm_project.presentation.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyPageResponse {
+    private String nickname;
+    private String investmentType;
+}


### PR DESCRIPTION


## 🔀 PR 개요
- 마이페이지 연동 및 사용자 닉네임/투자성향 수정 기능을 구현했습니다.

---

## ✅ 작업 내용
- 마이페이지 API 연동
- 닉네임 수정 API 추가 (PATCH /mypage/nickname)
- 투자성향 수정 API 추가 (PATCH /mypage/investment-type)

---

## 📌 관련 이슈
- Close #48


## ⚠️ 기타 사항
- 프론트엔드와 연동 테스트 완료
