### PR TITLE
Feat : 최근 미국 증시 뉴스를 배치로 가져온다 

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
@@ -4,6 +4,7 @@ import com.shinhan.pda_midterm_project.domain.disclosure.DisclosureProcessor;
 import com.shinhan.pda_midterm_project.domain.disclosure.DisclosureReader;
 import com.shinhan.pda_midterm_project.domain.disclosure.DisclosureWriter;
 import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
+import com.shinhan.pda_midterm_project.domain.main_news.service.MainNewsCrawlingTasklet;
 import com.shinhan.pda_midterm_project.domain.news.service.NewsCrawlingTasklet;
 import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
 import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
@@ -29,13 +30,27 @@ import java.util.List;
 
 @Slf4j
 @Configuration
-//@EnableBatchProcessing
 @RequiredArgsConstructor
 public class BatchConfig {
     private final NewsCrawlingTasklet newsCrawlingTasklet;
     private final DisclosureReader disclosureReader;
     private final DisclosureProcessor disclosureProcessor;
     private final DisclosureWriter disclosureWriter;
+    private final MainNewsCrawlingTasklet mainNewsCrawlingTasklet;
+
+    @Bean
+    public Job mainNewsCrawlingJob(JobRepository jobRepository, Step mainNewsCrawlingStep) {
+        return new JobBuilder("mainNewsCrawlingJob", jobRepository)
+                .start(mainNewsCrawlingStep)
+                .build();
+    }
+
+    @Bean
+    public Step mainNewsCrawlingStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("mainNewsCrawlingStep", jobRepository)
+                .tasklet(mainNewsCrawlingTasklet, transactionManager)
+                .build();
+    }
 
     @Bean
     public Job disclosureJob(JobRepository jobRepository, Step disclosureChunkStep) {

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -80,7 +80,12 @@ public enum ResponseMessages {
     /**
      * member stock
      */
-    MEMBER_NO_STOCKS("MEMBER-STOCK-001", "사용자의 보유종목이 없습니다.");
+    MEMBER_NO_STOCKS("MEMBER-STOCK-001", "사용자의 보유종목이 없습니다."),
+
+    /**
+     * main news
+     */
+    GET_CURRENT_MAIN_NEWS_SUCCESS("MAINNEWS-001", "최근 증시 뉴스 조회를 성공했습니다.");
 
     // 도메인 추가해주세요
     private final String code;

--- a/src/main/java/com/shinhan/pda_midterm_project/common/scheduler/MainNewsScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/scheduler/MainNewsScheduler.java
@@ -1,0 +1,30 @@
+package com.shinhan.pda_midterm_project.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class MainNewsScheduler {
+    private final JobLauncher jobLauncher;
+    private final Job mainNewsCrawlingJob;
+
+    @Scheduled(cron = "0 0 6 * * *")
+    public void runHeadlineNewsCrawlingJob() {
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("JobID", String.valueOf(System.currentTimeMillis()))
+                    .toJobParameters();
+            jobLauncher.run(mainNewsCrawlingJob, params);
+        } catch (Exception e) {
+            log.error("뉴스 크롤링 배치 작업 실행 중 오류 발생", e);
+        }
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/common/util/TimeUtil.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/util/TimeUtil.java
@@ -8,7 +8,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Date;
 
 public class TimeUtil {
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     public static Date localDateTimeToDate(LocalDateTime localDateTime, Clock clock) {
         return Date.from(localDateTime.atZone(clock.getZone()).toInstant());

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/auth/service/KoreaInvestmentServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/auth/service/KoreaInvestmentServiceImpl.java
@@ -159,6 +159,7 @@ public class KoreaInvestmentServiceImpl implements KoreaInvestmentService {
   @Override
   public UnifiedStockResponse getUnifiedStocks(String accountNumber, String accessToken, String appKey,
       String appSecret) {
+    System.out.println("accountNumber");
     try {
       List<UnifiedStockResponse.UnifiedStockItem> allStocks = new ArrayList<>();
 

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/model/MainNews.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/model/MainNews.java
@@ -1,0 +1,44 @@
+package com.shinhan.pda_midterm_project.domain.main_news.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MainNews {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT")
+    private String newsTitle;
+
+    @Column(columnDefinition = "TEXT")
+    private String newsContent;
+
+    @Column(columnDefinition = "TEXT")
+    private String newsUri;
+
+    private LocalDateTime newsDate;
+
+    public static MainNews create(String newsTitle, String newsContent, String newsUri, LocalDateTime newsDate) {
+        return MainNews.builder()
+                .newsTitle(newsTitle)
+                .newsContent(newsContent)
+                .newsUri(newsUri)
+                .newsDate(newsDate)
+                .build();
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/repository/MainNewsRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/repository/MainNewsRepository.java
@@ -1,0 +1,10 @@
+package com.shinhan.pda_midterm_project.domain.main_news.repository;
+
+import com.shinhan.pda_midterm_project.domain.main_news.model.MainNews;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MainNewsRepository extends JpaRepository<MainNews, Long> {
+    List<MainNews> findAllByOrderByIdDesc(Pageable pageable);
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/service/MainNewsCrawlingTasklet.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/service/MainNewsCrawlingTasklet.java
@@ -1,0 +1,52 @@
+package com.shinhan.pda_midterm_project.domain.main_news.service;
+
+import com.shinhan.pda_midterm_project.common.util.TimeUtil;
+import com.shinhan.pda_midterm_project.domain.main_news.model.MainNews;
+import com.shinhan.pda_midterm_project.domain.main_news.repository.MainNewsRepository;
+import com.shinhan.pda_midterm_project.presentation.news.dto.NewsCrawlingDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class MainNewsCrawlingTasklet implements Tasklet {
+    private final MainNewsRepository mainNewsRepository;
+    private final WebClient webClient;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        log.info("뉴스 크롤링 Tasklet 시작");
+        NewsCrawlingDto.Response response = webClient.get()
+                .uri("/market/crawl_news")
+                .retrieve()
+                .bodyToMono(NewsCrawlingDto.Response.class)
+                .block();
+
+        if (response == null) {
+            log.warn("크롤링 결과가 없거나 비어있습니다.");
+            return RepeatStatus.FINISHED;
+        }
+        System.out.println(response);
+        List<MainNews> mainNewsList = response.getCrawlResults()
+                .get("yahoo_finance_market_news")
+                .stream().map((result) -> MainNews.create(
+                        result.getNewsTitle(),
+                        result.getNewsContent(),
+                        result.getNewsUri(),
+                        TimeUtil.parseToLocalDateTime(result.getNewsDate())
+                )).toList();
+
+        mainNewsRepository.saveAll(mainNewsList);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/service/MainNewsService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/service/MainNewsService.java
@@ -1,0 +1,8 @@
+package com.shinhan.pda_midterm_project.domain.main_news.service;
+
+import com.shinhan.pda_midterm_project.domain.main_news.model.MainNews;
+import java.util.List;
+
+public interface MainNewsService {
+    List<MainNews> getCurrentMainNews();
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/service/MainNewsServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/main_news/service/MainNewsServiceImpl.java
@@ -1,0 +1,20 @@
+package com.shinhan.pda_midterm_project.domain.main_news.service;
+
+import com.shinhan.pda_midterm_project.domain.main_news.model.MainNews;
+import com.shinhan.pda_midterm_project.domain.main_news.repository.MainNewsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MainNewsServiceImpl implements MainNewsService {
+    private final MainNewsRepository mainNewsRepository;
+
+    public List<MainNews> getCurrentMainNews() {
+        Pageable pageable = PageRequest.of(0, 5);
+        return mainNewsRepository.findAllByOrderByIdDesc(pageable);
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/mainNews/controller/MainNewsController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/mainNews/controller/MainNewsController.java
@@ -1,0 +1,32 @@
+package com.shinhan.pda_midterm_project.presentation.mainNews.controller;
+
+import static com.shinhan.pda_midterm_project.common.response.ResponseMessages.GET_CURRENT_MAIN_NEWS_SUCCESS;
+
+import com.shinhan.pda_midterm_project.common.response.Response;
+import com.shinhan.pda_midterm_project.domain.main_news.model.MainNews;
+import com.shinhan.pda_midterm_project.domain.main_news.service.MainNewsService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/main-news")
+public class MainNewsController {
+    private final MainNewsService mainNewsService;
+
+    @GetMapping("/current")
+    public ResponseEntity<Response<List<MainNews>>> getCurrentMainNews() {
+        List<MainNews> currentMainNews = mainNewsService.getCurrentMainNews();
+        return ResponseEntity
+                .ok()
+                .body(Response.success(
+                        GET_CURRENT_MAIN_NEWS_SUCCESS.getCode(),
+                        GET_CURRENT_MAIN_NEWS_SUCCESS.getMessage(),
+                        currentMainNews
+                ));
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/news/dto/NewsCrawlingDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/news/dto/NewsCrawlingDto.java
@@ -41,4 +41,13 @@ public class NewsCrawlingDto {
         private String newsUri;
         private String newsDate;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @ToString
+    public static class MainNewsResponse {
+        @JsonProperty("crawl_results")
+        private List<CrawledArticle> crawlResults;
+    }
 }


### PR DESCRIPTION

## 🔀 PR 개요
- 최근 미국 증시 뉴스를 배치로 가져온다

---

## ✅ 작업 내용
- MainNews엔티티 추가
- 오전 6시에 data server로 배치해서 데이터를 가져오고, insert한다

---

## 📌 관련 이슈
- #43 

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
