### PR TITLE
Feat/notification read

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -99,6 +99,7 @@ public enum ResponseMessages {
      * notification
      */
     MARK_NOTIFICATION_AS_READ_SUCCESS("NOTI-001", "알림 읽음 처리에 성공했습니다."),
+    HAS_UNREAD_NOTIFICATION_SUCCESS("NOTI-002", "읽지 않은 알림 존재 여부 조회 성공"),
 
     /*
      * my page

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -95,6 +95,11 @@ public enum ResponseMessages {
      */
     GET_CURRENT_MAIN_NEWS_SUCCESS("MAINNEWS-001", "최근 증시 뉴스 조회를 성공했습니다."),
 
+    /**
+     * notification
+     */
+    MARK_NOTIFICATION_AS_READ_SUCCESS("NOTI-001", "알림 읽음 처리에 성공했습니다."),
+
     /*
      * my page
      */

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/model/Notification.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/model/Notification.java
@@ -33,4 +33,8 @@ public class Notification extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String notificationUrl;
+
+    public void markAsRead() {
+        this.notificationIsRead = true;
+    }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/repository/NotificationRepository.java
@@ -12,4 +12,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
 
     List<Notification> findByMemberId(Long memberId);
+
+    boolean existsByMemberIdAndNotificationIsReadFalse(Long memberId);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -17,6 +17,8 @@ public class NotificationScheduler {
     private final JobLauncher jobLauncher;
     private final Job notificationSendJob;
 
+
+//    @Scheduled(cron = "0 */1 * * * ?")
     @Scheduled(cron = "0 0 8 * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -17,9 +17,8 @@ public class NotificationScheduler {
     private final JobLauncher jobLauncher;
     private final Job notificationSendJob;
 
-
+//    @Scheduled(cron = "0 0 8 * * ?")
 //    @Scheduled(cron = "0 */1 * * * ?")
-    @Scheduled(cron = "0 0 8 * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");
 

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -111,4 +111,9 @@ public class NotificationService {
             notificationRepository.save(notification);
         }
     }
+
+    public boolean hasUnreadNotifications(Long memberId) {
+        return notificationRepository.existsByMemberIdAndNotificationIsReadFalse(memberId);
+    }
+
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -94,5 +95,20 @@ public class NotificationService {
                         .time(n.getCreatedAt())
                         .build())
                 .toList();
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 알림이 존재하지 않습니다."));
+
+        if (!notification.getMember().getId().equals(memberId)) {
+            throw new SecurityException("알림 소유자가 아닙니다.");
+        }
+
+        if (!Boolean.TRUE.equals(notification.getNotificationIsRead())) {
+            notification.markAsRead(); // 엔티티에서 처리
+            notificationRepository.save(notification);
+        }
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
@@ -9,6 +9,7 @@ import com.shinhan.pda_midterm_project.common.response.Response;
 
 import com.shinhan.pda_midterm_project.presentation.notification.dto.NotificationResponseDto;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -52,6 +53,16 @@ public class NotificationController {
         return ResponseEntity.ok(Response.success(
                 ResponseMessages.MARK_NOTIFICATION_AS_READ_SUCCESS.getCode(),
                 ResponseMessages.MARK_NOTIFICATION_AS_READ_SUCCESS.getMessage()
+        ));
+    }
+
+    @GetMapping("/unread-exists")
+    public ResponseEntity<?> hasUnreadNotifications(@Auth Accessor accessor) {
+        boolean hasUnread = notificationService.hasUnreadNotifications(accessor.memberId());
+        return ResponseEntity.ok(Response.success(
+                ResponseMessages.HAS_UNREAD_NOTIFICATION_SUCCESS.getCode(),
+                ResponseMessages.HAS_UNREAD_NOTIFICATION_SUCCESS.getMessage(),
+                Map.of("hasUnread", hasUnread)
         ));
     }
 

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.shinhan.pda_midterm_project.presentation.notification.controller;
 
 import com.shinhan.pda_midterm_project.common.annotation.Auth;
 import com.shinhan.pda_midterm_project.common.annotation.MemberOnly;
+import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
 import com.shinhan.pda_midterm_project.domain.notification.service.NotificationService;
 import com.shinhan.pda_midterm_project.common.response.Response;
@@ -40,6 +41,18 @@ public class NotificationController {
         Long memberId = accessor.memberId();
         List<NotificationResponseDto> result = notificationService.getByMemberId(memberId);
         return ResponseEntity.ok(Response.success("200", "알림 조회 성공", result));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @MemberOnly
+    public ResponseEntity<Response<Object>> markAsRead(@Auth Accessor accessor,
+                                                       @PathVariable Long notificationId) {
+        Long memberId = accessor.memberId();
+        notificationService.markAsRead(notificationId, memberId);
+        return ResponseEntity.ok(Response.success(
+                ResponseMessages.MARK_NOTIFICATION_AS_READ_SUCCESS.getCode(),
+                ResponseMessages.MARK_NOTIFICATION_AS_READ_SUCCESS.getMessage()
+        ));
     }
 
     /**


### PR DESCRIPTION


## 🔀 PR 개요
- 알림 읽음 처리 API 구현 및 상태 반영

---

## ✅ 작업 내용
- 알림 읽음 처리 API 엔드포인트 추가 (`PATCH /notifications/{id}/read`)
- Notification 엔티티에 `notificationIsRead` 상태 변경 메서드 적용
- 읽음 처리된 알림은 재조회 시 반영되도록 Repository 및 조회 로직 수정
- 읽음 여부를 확인하는 미리보기 API(`/unread-exists`)와 연동 가능하도록 상태 일관성 유지

---

## 📌 관련 이슈
- Close #54 

