### PR TITLE
fix: 뉴스 저장 시 이미지 URL 필드 추가

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/domain/news/service/NewsCrawlingTasklet.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/news/service/NewsCrawlingTasklet.java
@@ -68,6 +68,7 @@ public class NewsCrawlingTasklet implements Tasklet {
                             .newsContent(article.getNewsContent())
                             .newsUri(article.getNewsUri())
                             .newsDate(article.getNewsDate())
+                            .newsImage(article.getNewsImage())
                             .build());
                 }
             }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/news/service/NewsScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/news/service/NewsScheduler.java
@@ -23,7 +23,6 @@ public class NewsScheduler {
 
     // 매일 오전 7시에 실행 (cron = "0 0 7 * * *")
     // 테스트를 위해 1분마다 실행하려면 "0 */1 * * * ?"
-//    @Scheduled(cron = "0 */5 * * * ?")
     @Scheduled(cron = "0 0 7 * * *")
     public void runNewsCrawlingJob() {
         log.info("뉴스 크롤링 배치 작업을 시작합니다.");

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/news/dto/NewsCrawlingDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/news/dto/NewsCrawlingDto.java
@@ -40,6 +40,7 @@ public class NewsCrawlingDto {
         private String newsContent;
         private String newsUri;
         private String newsDate;
+        private String newsImage;
     }
 
     @Getter


### PR DESCRIPTION


## 🔀 PR 개요
- FastAPI 크롤링 뉴스에 newsImage 필드를 추가하고, Spring에서 이를 수신 및 저장하는 기능 구현

---

## ✅ 작업 내용
- NewsDto에 newsImage 필드 추가
- 이미지 포함된 뉴스가 DB에 저장되도록 처리

---

## 📌 관련 이슈
- Close #66 

---

## 📸 스크린샷
<img width="343" height="787" alt="스크린샷 2025-07-23 오전 10 05 51" src="https://github.com/user-attachments/assets/14298b65-af15-474a-9527-99375712c896" />
---

## ⚠️ 기타 사항
- astAPI 응답 스키마가 변경되었으므로, 연동 테스트 필요
