### PR TITLE
Feat : 개별 조회 및 1년치 공시데이터 INSERT 로직을 추가한다

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/config/BatchConfig.java
@@ -111,10 +111,10 @@ public class BatchConfig {
 
     @Bean
     public Step notificationSendStep(JobRepository jobRepository,
-                           PlatformTransactionManager transactionManager,
-                           ListItemReader<Long> memberIdReader,
-                           ItemProcessor<Long, List<Notification>> notificationProcessor,
-                           ItemWriter<List<Notification>> notificationWriter) {
+                                     PlatformTransactionManager transactionManager,
+                                     ListItemReader<Long> memberIdReader,
+                                     ItemProcessor<Long, List<Notification>> notificationProcessor,
+                                     ItemWriter<List<Notification>> notificationWriter) {
 
         return new StepBuilder("notificationSendStep", jobRepository)
                 .<Long, List<Notification>>chunk(5, transactionManager) // 일단 테스트 수준에서 5명씩 처리

--- a/src/main/java/com/shinhan/pda_midterm_project/common/config/DisclosureInitBatch.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/config/DisclosureInitBatch.java
@@ -1,0 +1,57 @@
+package com.shinhan.pda_midterm_project.common.config;
+
+import com.shinhan.pda_midterm_project.common.util.FastApiClient;
+import com.shinhan.pda_midterm_project.common.util.TimeUtil;
+import com.shinhan.pda_midterm_project.domain.disclosure.dto.DisclosureRequestDto;
+import com.shinhan.pda_midterm_project.domain.disclosure.dto.DisclosureResponseDto;
+import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
+import com.shinhan.pda_midterm_project.domain.disclosure.repository.DisclosureRepository;
+import com.shinhan.pda_midterm_project.domain.stock.model.Stock;
+import com.shinhan.pda_midterm_project.domain.stock.repository.StockRepository;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class DisclosureInitBatch {
+    private final StockRepository stockRepository;
+    private final DisclosureRepository disclosureRepository;
+    private final Clock clock;
+    private final FastApiClient fastApiClient;
+
+    public void runDisclosureBatch() {
+        List<Stock> stocks = stockRepository.findAll();
+        for (Stock stock : stocks) {
+            String stockId = stock.getStockId();
+            System.out.println(stockId + " 분석을 시작합니다");
+
+            DisclosureRequestDto request = DisclosureRequestDto.create(
+                    stockId, LocalDate.now(clock).minusDays(365).toString(),
+                    LocalDate.now(clock).toString());
+
+            DisclosureResponseDto response = fastApiClient.requestDisclosure(request);
+
+            if (response.results().isEmpty()) {
+                continue;
+            }
+            List<Disclosure> disclosures = response.results().stream()
+                    .map(disclosureResult -> {
+                        LocalDate filingDate = TimeUtil.stringToLocalDate(disclosureResult.filing_date());
+                        return Disclosure.create(
+                                stock,
+                                disclosureResult.title(),
+                                filingDate,
+                                disclosureResult.narrative()
+                        );
+                    }).toList();
+            disclosureRepository.saveAll(disclosures);
+        }
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -70,6 +70,8 @@ public enum ResponseMessages {
      * disclosure
      */
     GET_MY_CURRENT_DISCLOSURE_SUCCESS("DISCLOSURE-001", "나의 최근 공시정보를 성공적으로 조회했습니다."),
+    GET_DISCLOSURE_DETAIL_FAIL("DISCLOSURE-002", "공시 정보 세부사항을 가져오는 것을 실패했습니다."),
+    GET_DISCLOSURE_DETAIL_SUCCESS("DISCLOSURE-003", "공시 정보 세부사항을 가져오는 것을 성공했습니다."),
 
     /**
      * common

--- a/src/main/java/com/shinhan/pda_midterm_project/common/util/FastApiClient.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/util/FastApiClient.java
@@ -12,7 +12,7 @@ public class FastApiClient {
 
     private final WebClient fastApiWebClient;
 
-    public DisclosureResponseDto requestTodayDisclosure(DisclosureRequestDto requestDto) {
+    public DisclosureResponseDto requestDisclosure(DisclosureRequestDto requestDto) {
         return fastApiWebClient.post()
                 .uri("/analyze-8k")
                 .bodyValue(requestDto)

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/DisclosureProcessor.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/DisclosureProcessor.java
@@ -29,7 +29,7 @@ public class DisclosureProcessor implements ItemProcessor<Stock, Disclosure> {
             DisclosureRequestDto request = DisclosureRequestDto.create(
                     stock.getStockId(), LocalDate.now(clock).minusDays(1).toString(), LocalDate.now(clock).toString());
 
-            DisclosureResponseDto response = fastApiClient.requestTodayDisclosure(request);
+            DisclosureResponseDto response = fastApiClient.requestDisclosure(request);
             System.out.println(response.results());
             if (response.results().isEmpty()) {
                 index = 0;

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/dto/DisclosureSimpleDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/dto/DisclosureSimpleDto.java
@@ -2,8 +2,18 @@ package com.shinhan.pda_midterm_project.domain.disclosure.dto;
 
 import java.time.LocalDate;
 
-public record DisclosureSimpleDto(String disclosureTitle, String disclosureSummary, LocalDate disclosureDate) {
-    public static DisclosureSimpleDto of(String disclosureTitle, String disclosureSummary, LocalDate disclosureDate) {
-        return new DisclosureSimpleDto(disclosureTitle, disclosureSummary, disclosureDate);
+public record DisclosureSimpleDto(
+        Long id,
+        String disclosureTitle,
+        String disclosureSummary,
+        LocalDate disclosureDate,
+        String stockId) {
+    public static DisclosureSimpleDto of(
+            Long id,
+            String disclosureTitle,
+            String disclosureSummary,
+            LocalDate disclosureDate,
+            String stockId) {
+        return new DisclosureSimpleDto(id, disclosureTitle, disclosureSummary, disclosureDate, stockId);
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/dto/DisclosureSimpleDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/dto/DisclosureSimpleDto.java
@@ -7,13 +7,15 @@ public record DisclosureSimpleDto(
         String disclosureTitle,
         String disclosureSummary,
         LocalDate disclosureDate,
+        String stockName,
         String stockId) {
     public static DisclosureSimpleDto of(
             Long id,
             String disclosureTitle,
             String disclosureSummary,
             LocalDate disclosureDate,
+            String stockName,
             String stockId) {
-        return new DisclosureSimpleDto(id, disclosureTitle, disclosureSummary, disclosureDate, stockId);
+        return new DisclosureSimpleDto(id, disclosureTitle, disclosureSummary, disclosureDate, stockName, stockId);
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/exception/DisclosureException.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/exception/DisclosureException.java
@@ -1,0 +1,16 @@
+package com.shinhan.pda_midterm_project.domain.disclosure.exception;
+
+import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
+
+public class DisclosureException extends RuntimeException {
+    private final ResponseMessages responseMessage;
+
+    public DisclosureException(ResponseMessages responseMessage) {
+        super(responseMessage.getMessage());
+        this.responseMessage = responseMessage;
+    }
+
+    public String getCode() {
+        return responseMessage.getCode();
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureService.java
@@ -5,4 +5,6 @@ import java.util.List;
 
 public interface DisclosureService {
     List<DisclosureSimpleDto> getMyCurrentDisclosure(Long memberId);
+
+    DisclosureSimpleDto getMonoDisclosure(Long disclosureId);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureServiceImpl.java
@@ -1,6 +1,8 @@
 package com.shinhan.pda_midterm_project.domain.disclosure.service;
 
+import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.disclosure.dto.DisclosureSimpleDto;
+import com.shinhan.pda_midterm_project.domain.disclosure.exception.DisclosureException;
 import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
 import com.shinhan.pda_midterm_project.domain.disclosure.repository.DisclosureRepository;
 import java.util.List;
@@ -14,14 +16,37 @@ import org.springframework.stereotype.Service;
 public class DisclosureServiceImpl implements DisclosureService {
     private final DisclosureRepository disclosureRepository;
 
+    @Override
     public List<DisclosureSimpleDto> getMyCurrentDisclosure(Long memberID) {
         Pageable pageable = PageRequest.of(0, 5);
         List<Disclosure> myCurrentDisclosure = disclosureRepository.getMyCurrentDisclosure(memberID, pageable);
 
         return myCurrentDisclosure.stream().map((disclosure)
-                -> DisclosureSimpleDto.of(
+                        -> DisclosureSimpleDto.of(
+                        disclosure.getId(),
+                        disclosure.getDisclosureTitle(),
+                        disclosure.getDisclosureSummary(),
+                        disclosure.getDisclosureDate(),
+                        disclosure.getStock().getStockId()))
+                .toList();
+    }
+
+    @Override
+    public DisclosureSimpleDto getMonoDisclosure(Long disclosureId) {
+        Disclosure disclosure = findDisclosureById(disclosureId);
+
+        return DisclosureSimpleDto.of(
+                disclosure.getId(),
                 disclosure.getDisclosureTitle(),
                 disclosure.getDisclosureSummary(),
-                disclosure.getDisclosureDate())).toList();
+                disclosure.getDisclosureDate(),
+                disclosure.getStock().getStockId()
+        );
+    }
+
+    public Disclosure findDisclosureById(Long disclosureId) {
+        return disclosureRepository.findById(disclosureId).orElseThrow(() ->
+                new DisclosureException(ResponseMessages.GET_DISCLOSURE_DETAIL_FAIL)
+        );
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureServiceImpl.java
@@ -27,6 +27,7 @@ public class DisclosureServiceImpl implements DisclosureService {
                         disclosure.getDisclosureTitle(),
                         disclosure.getDisclosureSummary(),
                         disclosure.getDisclosureDate(),
+                        disclosure.getStock().getStockName(),
                         disclosure.getStock().getStockId()))
                 .toList();
     }
@@ -40,6 +41,7 @@ public class DisclosureServiceImpl implements DisclosureService {
                 disclosure.getDisclosureTitle(),
                 disclosure.getDisclosureSummary(),
                 disclosure.getDisclosureDate(),
+                disclosure.getStock().getStockName(),
                 disclosure.getStock().getStockId()
         );
     }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/disclosure/controller/DisclosureController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/disclosure/controller/DisclosureController.java
@@ -2,6 +2,7 @@ package com.shinhan.pda_midterm_project.presentation.disclosure.controller;
 
 import com.shinhan.pda_midterm_project.common.annotation.Auth;
 import com.shinhan.pda_midterm_project.common.annotation.MemberOnly;
+import com.shinhan.pda_midterm_project.common.config.DisclosureInitBatch;
 import com.shinhan.pda_midterm_project.common.response.Response;
 import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DisclosureController {
     private final DisclosureService disclosureService;
+    private final DisclosureInitBatch disclosureInitBatch;
 
     @MemberOnly
     @GetMapping("/my-current-disclosure")
@@ -32,6 +34,18 @@ public class DisclosureController {
                         ResponseMessages.GET_MY_CURRENT_DISCLOSURE_SUCCESS.getCode(),
                         ResponseMessages.GET_MY_CURRENT_DISCLOSURE_SUCCESS.getMessage(),
                         myCurrentDisclosure
+                ));
+    }
+
+    @GetMapping("/init")
+    public ResponseEntity<Response<List<String>>> disclosureInit() {
+        disclosureInitBatch.runDisclosureBatch();
+
+        return ResponseEntity
+                .ok()
+                .body(Response.success(
+                        ResponseMessages.SUCCESS.getCode(),
+                        ResponseMessages.SUCCESS.getMessage()
                 ));
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/disclosure/controller/DisclosureController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/disclosure/controller/DisclosureController.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,6 +47,20 @@ public class DisclosureController {
                 .body(Response.success(
                         ResponseMessages.SUCCESS.getCode(),
                         ResponseMessages.SUCCESS.getMessage()
+                ));
+    }
+
+    @GetMapping("/{disclosureId}")
+    @MemberOnly
+    public ResponseEntity<Response<DisclosureSimpleDto>> getDisclosureDetail(@PathVariable Long disclosureId,
+                                                                             @Auth Accessor accessor) {
+        DisclosureSimpleDto monoDisclosure = disclosureService.getMonoDisclosure(disclosureId);
+        return ResponseEntity
+                .ok()
+                .body(Response.success(
+                        ResponseMessages.GET_DISCLOSURE_DETAIL_SUCCESS.getCode(),
+                        ResponseMessages.GET_DISCLOSURE_DETAIL_SUCCESS.getMessage(),
+                        monoDisclosure
                 ));
     }
 }


### PR DESCRIPTION
## 🔀 PR 개요
- 개별 조회 및 1년치 공시데이터 INSERT 로직을 추가

---

## ✅ 작업 내용
- 공시 정보 response 할 때, stock id와 stock name을 같이 response하도록 변경한다
- 개별 공시 조회를 구현한다
- stock별 1년치 공시를 insert하는 로직을 구현한다

---

## 📌 관련 이슈
- Close #83 

---

## 📸 스크린샷 (선택)


---

## ⚠️ 기타 사항

