### PR TITLE
Feat/notification earning disclosure

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/repository/DisclosureRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/repository/DisclosureRepository.java
@@ -1,6 +1,7 @@
 package com.shinhan.pda_midterm_project.domain.disclosure.repository;
 
 import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,6 @@ public interface DisclosureRepository extends JpaRepository<Disclosure, Long> {
                 ORDER BY d.disclosureDate DESC
             """)
     List<Disclosure> getMyCurrentDisclosure(@Param("memberId") Long memberId, Pageable pageable);
+
+    List<Disclosure> findByDisclosureDate(LocalDate today);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureAlarmScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureAlarmScheduler.java
@@ -28,7 +28,7 @@ public class DisclosureAlarmScheduler {
 
 //    @Scheduled(cron = "0 40 7 * * *")
     @Transactional
-    @Scheduled(cron = "0 */1 * * * ?")
+    @Scheduled(cron = "0 40 7 * * *")
     public void sendDisclosureNotifications() {
         LocalDate today = LocalDate.now();
         List<Disclosure> todayDisclosures = disclosureRepository.findByDisclosureDate(today);

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureAlarmScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureAlarmScheduler.java
@@ -1,0 +1,57 @@
+package com.shinhan.pda_midterm_project.domain.disclosure.service;
+
+import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
+import com.shinhan.pda_midterm_project.domain.disclosure.repository.DisclosureRepository;
+import com.shinhan.pda_midterm_project.domain.member.model.Member;
+import com.shinhan.pda_midterm_project.domain.member_stock.model.MemberStock;
+import com.shinhan.pda_midterm_project.domain.member_stock.repository.MemberStockRepository;
+import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
+import com.shinhan.pda_midterm_project.domain.notification.model.NotificationType;
+import com.shinhan.pda_midterm_project.domain.notification.repository.NotificationRepository;
+import com.shinhan.pda_midterm_project.domain.stock.model.Stock;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DisclosureAlarmScheduler {
+
+    private final DisclosureRepository disclosureRepository;
+    private final MemberStockRepository memberStockRepository;
+    private final NotificationRepository notificationRepository;
+
+//    @Scheduled(cron = "0 40 7 * * *")
+    @Transactional
+    @Scheduled(cron = "0 */1 * * * ?")
+    public void sendDisclosureNotifications() {
+        LocalDate today = LocalDate.now();
+        List<Disclosure> todayDisclosures = disclosureRepository.findByDisclosureDate(today);
+
+        for (Disclosure disclosure : todayDisclosures) {
+            Stock stock = disclosure.getStock();
+            List<MemberStock> holders = memberStockRepository.findByStock(stock);
+
+            for (MemberStock memberStock : holders) {
+                Member member = memberStock.getMember();
+
+                Notification notification = Notification.builder()
+                        .member(member)
+                        .notificationTitle("오늘의 공시 - " + stock.getOvrsItemName())
+                        .notificationContent(disclosure.getDisclosureTitle())
+                        .notificationIsRead(false)
+                        .notificationType(NotificationType.DISCLOSURE)
+                        .notificationUrl("/stocks/" + stock.getRsym())
+                        .build();
+
+                notificationRepository.save(notification);
+            }
+        }
+        log.info(">>> [Disclosure] 공시 전송 완료");
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/earning_call/service/EarningCallAlarmScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/earning_call/service/EarningCallAlarmScheduler.java
@@ -1,0 +1,56 @@
+package com.shinhan.pda_midterm_project.domain.earning_call.service;
+
+import com.shinhan.pda_midterm_project.domain.earning_call.model.EarningCall;
+import com.shinhan.pda_midterm_project.domain.earning_call.repository.EarningCallRepository;
+import com.shinhan.pda_midterm_project.domain.member.model.Member;
+import com.shinhan.pda_midterm_project.domain.member_stock.model.MemberStock;
+import com.shinhan.pda_midterm_project.domain.member_stock.repository.MemberStockRepository;
+import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
+import com.shinhan.pda_midterm_project.domain.notification.repository.NotificationRepository;
+import com.shinhan.pda_midterm_project.domain.stock.model.Stock;
+import com.shinhan.pda_midterm_project.domain.notification.model.NotificationType;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EarningCallAlarmScheduler {
+
+    private final EarningCallRepository earningCallRepository;
+    private final MemberStockRepository memberStockRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Scheduled(cron = "0 30 7 * * * ")
+    @Transactional
+    public void sendEarningCallNotification() {
+        String today = LocalDate.now().toString();
+        List<EarningCall> todayCalls = earningCallRepository.findByEarningCallDate(today);
+
+        for (EarningCall call : todayCalls) {
+            Stock stock = call.getStock();
+            List<MemberStock> holders = memberStockRepository.findByStock(stock);
+
+            for (MemberStock ms : holders) {
+                Member member = ms.getMember();
+
+                Notification notification = Notification.builder()
+                        .member(member)
+                        .notificationTitle("오늘의 어닝콜 알림")
+                        .notificationContent(stock.getOvrsItemName() + " 종목이 오늘 어닝콜 예정입니다.")
+                        .notificationIsRead(false)
+                        .notificationUrl(null)
+                        .notificationType(NotificationType.EARNINGS_CALL)
+                        .build();
+
+                notificationRepository.save(notification);
+                log.info(">>> [EarningCall] 오늘의 어닝콜 저장 완료");
+            }
+        }
+    }
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/member_stock/repository/MemberStockRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/member_stock/repository/MemberStockRepository.java
@@ -25,4 +25,5 @@ public interface MemberStockRepository extends JpaRepository<MemberStock, Long> 
   @Query("SELECT ms.member FROM MemberStock ms WHERE ms.stock.stockId = :stockId")
   List<Member> findAllByStockId(@Param("stockId") String stockId);
 
+    List<MemberStock> findByStock(Stock stock);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/news/service/NewsScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/news/service/NewsScheduler.java
@@ -23,7 +23,7 @@ public class NewsScheduler {
 
     // 매일 오전 7시에 실행 (cron = "0 0 7 * * *")
     // 테스트를 위해 1분마다 실행하려면 "0 */1 * * * ?"
-    @Scheduled(cron = "0 0 7 * * *")
+//    @Scheduled(cron = "0 */1 * * * ?")
     public void runNewsCrawlingJob() {
         log.info("뉴스 크롤링 배치 작업을 시작합니다.");
 

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/model/Notification.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/model/Notification.java
@@ -1,9 +1,7 @@
 package com.shinhan.pda_midterm_project.domain.notification.model;
 
 import com.shinhan.pda_midterm_project.common.util.BaseEntity;
-import com.shinhan.pda_midterm_project.domain.investment_type.model.InvestmentType;
 import com.shinhan.pda_midterm_project.domain.member.model.Member;
-import com.shinhan.pda_midterm_project.domain.notification.model.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -33,6 +31,10 @@ public class Notification extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String notificationUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType notificationType;
 
     public void markAsRead() {
         this.notificationIsRead = true;

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/model/NotificationType.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/model/NotificationType.java
@@ -1,0 +1,7 @@
+package com.shinhan.pda_midterm_project.domain.notification.model;
+
+public enum NotificationType {
+    SUMMARY_COMPLETE,
+    EARNINGS_CALL,
+    DISCLOSURE
+}

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -19,7 +19,8 @@ public class NotificationScheduler {
 
 
 //    @Scheduled(cron = "0 */1 * * * ?")
-    @Scheduled(cron = "0 0 8 * * ?")
+//    @Scheduled(cron = "0 0 8 * * ?")
+    @Scheduled(cron = "0 */1 * * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");
 

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -6,7 +6,6 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationScheduler.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,8 +17,9 @@ public class NotificationScheduler {
     private final JobLauncher jobLauncher;
     private final Job notificationSendJob;
 
-//    @Scheduled(cron = "0 0 8 * * ?")
+
 //    @Scheduled(cron = "0 */1 * * * ?")
+    @Scheduled(cron = "0 0 8 * * ?")
     public void sendMorningNotifications() {
         log.info("아침 8시! 접속 중인 유저에게 알림 발송 시작");
 

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/notification/service/NotificationService.java
@@ -93,6 +93,7 @@ public class NotificationService {
                         .message(n.getNotificationContent())
                         .read(n.getNotificationIsRead())
                         .time(n.getCreatedAt())
+                        .type(n.getNotificationType().name())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/total_summary/service/TotalSummaryService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/total_summary/service/TotalSummaryService.java
@@ -10,6 +10,7 @@ import com.shinhan.pda_midterm_project.domain.member.repository.MemberRepository
 import com.shinhan.pda_midterm_project.domain.member_stock_snapshot.model.MemberStockSnapshot;
 import com.shinhan.pda_midterm_project.domain.member_stock_snapshot.repository.MemberStockSnapshotRepository;
 import com.shinhan.pda_midterm_project.domain.notification.model.Notification;
+import com.shinhan.pda_midterm_project.domain.notification.model.NotificationType;
 import com.shinhan.pda_midterm_project.domain.notification.repository.NotificationRepository;
 import com.shinhan.pda_midterm_project.domain.total_summary.model.TotalSummary;
 import com.shinhan.pda_midterm_project.domain.total_summary.repository.TotalSummaryRepository;
@@ -88,6 +89,7 @@ public class TotalSummaryService {
                     .notificationContent(content)
 //                    .notificationUrl("/total-summary")
                     .notificationIsRead(false)
+                    .notificationType(NotificationType.SUMMARY_COMPLETE)
                     .build();
 
             notificationRepository.save(notification);

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/notification/dto/NotificationResponseDto.java
@@ -10,5 +10,6 @@ public record NotificationResponseDto(
         String title,
         String message,
         Boolean read,
-        LocalDateTime time
+        LocalDateTime time,
+        String type
 ) {}


### PR DESCRIPTION


## 🔀 PR 개요
- 어닝콜 및 공시 일정 기반 알림 생성 및 전송 기능 구현

---

## ✅ 작업 내용
- NotificationType에 EARNINGS_CALL, DISCLOSURE 타입 추가
- 어닝콜/공시 일정 기반으로 알림 생성하는 스케줄러 구현 (@Scheduled)
- 사용자가 보유한 종목 중, 해당 일정이 있는 종목에 대해 알림 생성
- 알림 전송 로직과 SSE 연동 확인
- 테스트 데이터 기준 정상 발송 테스트 완료

---

## 📌 관련 이슈
- Close #79 

