### PR TITLE
Feat : 내 주신 관련 공시 데이터 전체를 가져오는 api를 구현한다

### DIFF
--- a/src/main/java/com/shinhan/pda_midterm_project/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/handler/GlobalExceptionHandler.java
@@ -2,9 +2,9 @@ package com.shinhan.pda_midterm_project.common.handler;
 
 import com.shinhan.pda_midterm_project.common.response.Response;
 import com.shinhan.pda_midterm_project.domain.auth.exception.AuthException;
+import com.shinhan.pda_midterm_project.domain.disclosure.exception.DisclosureException;
 import com.shinhan.pda_midterm_project.domain.member.exception.MemberException;
 import com.shinhan.pda_midterm_project.domain.member_stock.exception.MemberStockException;
-import com.shinhan.pda_midterm_project.domain.member_stock.model.MemberStock;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthException.class)
     public ResponseEntity<Response<String>> handleAuthException(AuthException ex) {
         return ResponseEntity
-                .badRequest()
+                .status(403)
                 .body(Response.failure(ex.getCode(), ex.getMessage()));
     }
 
@@ -46,5 +46,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(Response.failure(ex.getCode(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(DisclosureException.class)
+    public ResponseEntity<Response<String>> handleDisclosureException(DisclosureException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(Response.success(ex.getCode(), ex.getMessage()));
     }
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/common/response/ResponseMessages.java
@@ -72,6 +72,7 @@ public enum ResponseMessages {
     GET_MY_CURRENT_DISCLOSURE_SUCCESS("DISCLOSURE-001", "나의 최근 공시정보를 성공적으로 조회했습니다."),
     GET_DISCLOSURE_DETAIL_FAIL("DISCLOSURE-002", "공시 정보 세부사항을 가져오는 것을 실패했습니다."),
     GET_DISCLOSURE_DETAIL_SUCCESS("DISCLOSURE-003", "공시 정보 세부사항을 가져오는 것을 성공했습니다."),
+    GET_DISCLOSURES_SUCCESS("DISCLOSURE-004", "나의 전체 공시 정보를 가져오는 것을 성공했습니다."),
 
     /**
      * common

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/auth/exception/AuthException.java
@@ -17,4 +17,3 @@ public class AuthException extends RuntimeException {
         return responseMessage.getCode();
     }
 }
-

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/auth/service/TokenCookieManager.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/auth/service/TokenCookieManager.java
@@ -22,7 +22,7 @@ public class TokenCookieManager {
     public static ResponseCookie createCookie(String tokenValue) {
         return ResponseCookie.from(TOKEN_NAME, tokenValue)
                 .maxAge(COOKIE_MAX_AGE)
-                .secure(false)
+                .secure(true)
                 .httpOnly(true)
                 .sameSite("none")
                 .path("/")

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/repository/DisclosureRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/repository/DisclosureRepository.java
@@ -1,6 +1,7 @@
 package com.shinhan.pda_midterm_project.domain.disclosure.repository;
 
 import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,17 @@ public interface DisclosureRepository extends JpaRepository<Disclosure, Long> {
                 ORDER BY d.disclosureDate DESC
             """)
     List<Disclosure> getMyCurrentDisclosure(@Param("memberId") Long memberId, Pageable pageable);
+
+    @Query("""
+                SELECT d
+                FROM Disclosure d
+                JOIN d.stock s
+                WHERE s.stockId IN (
+                    SELECT ms.stock.stockId
+                    FROM MemberStock ms
+                    WHERE ms.member.id = :memberId
+                )
+                ORDER BY d.disclosureDate DESC
+            """)
+    List<Disclosure> getMyCurrentDisclosures(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/repository/DisclosureRepository.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/repository/DisclosureRepository.java
@@ -37,4 +37,6 @@ public interface DisclosureRepository extends JpaRepository<Disclosure, Long> {
                 ORDER BY d.disclosureDate DESC
             """)
     List<Disclosure> getMyDisclosures(@Param("memberId") Long memberId);
+
+    List<Disclosure> findByDisclosureDate(LocalDate today);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureService.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureService.java
@@ -1,10 +1,13 @@
 package com.shinhan.pda_midterm_project.domain.disclosure.service;
 
 import com.shinhan.pda_midterm_project.domain.disclosure.dto.DisclosureSimpleDto;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface DisclosureService {
     List<DisclosureSimpleDto> getMyCurrentDisclosure(Long memberId);
 
     DisclosureSimpleDto getMonoDisclosure(Long disclosureId);
+
+    List<DisclosureSimpleDto> getMyDisclosures(Long memberId);
 }

--- a/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureServiceImpl.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/domain/disclosure/service/DisclosureServiceImpl.java
@@ -1,10 +1,12 @@
 package com.shinhan.pda_midterm_project.domain.disclosure.service;
 
 import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
+import com.shinhan.pda_midterm_project.common.util.TimeUtil;
 import com.shinhan.pda_midterm_project.domain.disclosure.dto.DisclosureSimpleDto;
 import com.shinhan.pda_midterm_project.domain.disclosure.exception.DisclosureException;
 import com.shinhan.pda_midterm_project.domain.disclosure.model.Disclosure;
 import com.shinhan.pda_midterm_project.domain.disclosure.repository.DisclosureRepository;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -44,6 +46,21 @@ public class DisclosureServiceImpl implements DisclosureService {
                 disclosure.getStock().getStockName(),
                 disclosure.getStock().getStockId()
         );
+    }
+
+    @Override
+    public List<DisclosureSimpleDto> getMyDisclosures(Long memberId) {
+        List<Disclosure> myCurrentDisclosureBetweenDates = disclosureRepository.getMyCurrentDisclosures(memberId);
+
+        return myCurrentDisclosureBetweenDates.stream()
+                .map((disclosure) -> DisclosureSimpleDto.of(
+                        disclosure.getId(),
+                        disclosure.getDisclosureTitle(),
+                        disclosure.getDisclosureSummary(),
+                        disclosure.getDisclosureDate(),
+                        disclosure.getStock().getStockName(),
+                        disclosure.getStock().getStockId()
+                )).toList();
     }
 
     public Disclosure findDisclosureById(Long disclosureId) {

--- a/src/main/java/com/shinhan/pda_midterm_project/presentation/disclosure/controller/DisclosureController.java
+++ b/src/main/java/com/shinhan/pda_midterm_project/presentation/disclosure/controller/DisclosureController.java
@@ -5,7 +5,9 @@ import com.shinhan.pda_midterm_project.common.annotation.MemberOnly;
 import com.shinhan.pda_midterm_project.common.config.DisclosureInitBatch;
 import com.shinhan.pda_midterm_project.common.response.Response;
 import com.shinhan.pda_midterm_project.common.response.ResponseMessages;
+import com.shinhan.pda_midterm_project.common.util.TimeUtil;
 import com.shinhan.pda_midterm_project.domain.auth.model.Accessor;
+import com.shinhan.pda_midterm_project.domain.disclosure.DisclosureProcessor;
 import com.shinhan.pda_midterm_project.domain.disclosure.dto.DisclosureSimpleDto;
 import com.shinhan.pda_midterm_project.domain.disclosure.service.DisclosureService;
 import java.util.List;
@@ -14,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -52,8 +55,10 @@ public class DisclosureController {
 
     @GetMapping("/{disclosureId}")
     @MemberOnly
-    public ResponseEntity<Response<DisclosureSimpleDto>> getDisclosureDetail(@PathVariable Long disclosureId,
-                                                                             @Auth Accessor accessor) {
+    public ResponseEntity<Response<DisclosureSimpleDto>> getDisclosureDetail(
+            @PathVariable Long disclosureId,
+            @Auth Accessor accessor
+    ) {
         DisclosureSimpleDto monoDisclosure = disclosureService.getMonoDisclosure(disclosureId);
         return ResponseEntity
                 .ok()
@@ -61,6 +66,23 @@ public class DisclosureController {
                         ResponseMessages.GET_DISCLOSURE_DETAIL_SUCCESS.getCode(),
                         ResponseMessages.GET_DISCLOSURE_DETAIL_SUCCESS.getMessage(),
                         monoDisclosure
+                ));
+    }
+
+    @GetMapping("/my-disclosures")
+    @MemberOnly
+    public ResponseEntity<Response<List<DisclosureSimpleDto>>> getMyDisclosures(
+            @Auth Accessor accessor
+    ) {
+        Long memberId = accessor.memberId();
+        List<DisclosureSimpleDto> disclosures = disclosureService.getMyDisclosures(memberId);
+
+        return ResponseEntity
+                .ok()
+                .body(Response.success(
+                        ResponseMessages.GET_DISCLOSURES_SUCCESS.getCode(),
+                        ResponseMessages.GET_DISCLOSURES_SUCCESS.getMessage(),
+                        disclosures
                 ));
     }
 }


### PR DESCRIPTION
## 🔀 PR 개요
- 내 주신 관련 공시 데이터 전체를 가져오는 api를 구현한다

---

## ✅ 작업 내용
- 내 주신 관련 공시 데이터 전체를 가져오는 api를 구현한다
- 
---

## 📌 관련 이슈
- Close #

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
